### PR TITLE
Update GitHub organization links from anti-work to antiwork

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -4,11 +4,11 @@
 Antiwork emerged from Gumroad's mission to automate repetitive tasks. In 2025, we're taking a bold step by open-sourcing our entire suite of tools that helped run and scale Gumroad. We believe in making powerful automation accessible to everyone.
 
 ## 🚀 Our Projects
-- **Shortest**: Natural language AI testing platform - [Contributions welcome](https://github.com/anti-work/shortest)
+- **Shortest**: Natural language AI testing platform - [Contributions welcome](https://github.com/antiwork/shortest)
 - **Flexile**: Team and shareholder management system
 - **Gumroad**: Sell your stuff. See what sticks
-- **Helper**: Customer support agents - [Contributions welcome](https://github.com/anti-work/helper)
-- **Iffy**: Keep your product clean - [Contributions welcome](https://github.com/anti-work/iffy)
+- **Helper**: Customer support agents - [Contributions welcome](https://github.com/antiwork/helper)
+- **Iffy**: Keep your product clean - [Contributions welcome](https://github.com/antiwork/iffy)
 
 ## 🌈 Contribution Guidelines
 We love our community and welcome contributions!


### PR DESCRIPTION
Update GitHub organization links from [github.com/anti-work](http://github.com/anti-work) to [github.com/antiwork](http://github.com/antiwork) as requested in Slack channel #antiwork